### PR TITLE
remove edit file.path at the end of relocate function

### DIFF
--- a/publisher_core/file.v
+++ b/publisher_core/file.v
@@ -88,7 +88,7 @@ fn (mut file File) relocate(mut publisher Publisher) ? {
 			file.mv(mut publisher, dest) ?
 		}
 	}
-	file.path = '/img_notused/${os.base(path)}'
+	// file.path = '/img_notused/${os.base(path)}'
 }
 
 // mark this file as duplicate from other file


### PR DESCRIPTION
## Description
set `file.path` always at the end of the relocate function leads to error when copy files to publish folder

## Related issue
see on: https://circles.threefold.me/project/despiegk-product_publisher/us/22?kanban-status=1602