### PR TITLE
Support coinmarketcap & liquid to get TFT prices

### DIFF
--- a/coinmarketcap/coinmarketcap.v
+++ b/coinmarketcap/coinmarketcap.v
@@ -65,8 +65,6 @@ fn (mut h CoinMarketConnection) header() ?http.Header {
 	*/
 	mut header := http.new_header_from_map(map{
 		http.CommonHeader.content_type:  'application/json'
-		http.CommonHeader.accept:  'application/json'
-		http.CommonHeader.accept_encoding: 'deflate, gzip'
 	})
 	header.add_custom('X-CMC_PRO_API_KEY', h.secret)?
 	return header
@@ -84,9 +82,9 @@ fn cache_key(prefix string, reqdata string) string {
 	*/
 	mut ckey := ''
 	if reqdata == '' {
-		ckey = 'taiga:' + prefix
+		ckey = 'coinmarketcap:' + prefix
 	} else {
-		ckey = 'taiga:' + prefix + ':' + md5.hexhash(reqdata)
+		ckey = 'coinmarketcap:' + prefix + ':' + md5.hexhash(reqdata)
 	}
 	return ckey
 }
@@ -137,69 +135,7 @@ fn (mut h CoinMarketConnection) cache_drop() ? {
 	// TODO:: maintain authentication & reconnect (Need More Info)
 }
 
-fn (mut h CoinMarketConnection) post_json(prefix string, postdata string, cache bool, authenticated bool) ?map[string]json2.Any {
-	/*
-	Post Request with Json Data
-	Inputs:
-		prefix: CoinMarket elements types, ex (projects, issues, tasks, ...).
-		postdata: Json encoded data.
-		cache: Flag to enable caching.
-		authenticated: Flag to add authorization flag with the request.
-
-	Output:
-		response: response as Json2 struct.
-	*/
-	mut result := h.cache_get(prefix, postdata, cache)
-	// Post with auth header
-	if result == '' && authenticated {
-		mut req := http.new_request(http.Method.post, '$h.url/api/v1/$prefix', postdata) ?
-		req.header = h.header() ?
-		println(req)
-		response := req.do() ?
-		result = response.text
-	}
-	// Post without auth header
-	else {
-		response := http.post_json('$h.url/api/v1/$prefix', postdata) ?
-		result = response.text
-	}
-	h.cache_set(prefix, postdata, result, cache) ?
-	data_raw := json2.raw_decode(result) ?
-	data := data_raw.as_map()
-	return data
-}
-
-fn (mut h CoinMarketConnection) post_json_str(prefix string, postdata string, cache bool, authenticated bool) ?string {
-	/*
-	Post Request with Json Data
-	Inputs:
-		prefix: CoinMarket elements types, ex (projects, issues, tasks, ...).
-		postdata: Json encoded data.
-		cache: Flag to enable caching.
-		authenticated: Flag to add authorization flag with the request.
-
-	Output:
-		response: response as string.
-	*/
-	mut result := h.cache_get(prefix, postdata, cache)
-	// Post with auth header
-	if result == '' && authenticated {
-		mut req := http.new_request(http.Method.post, '$h.url/api/v1/$prefix', postdata) ?
-		req.header = h.header() ?
-		println(req)
-		response := req.do() ?
-		result = response.text
-	}
-	// Post without auth header
-	else {
-		response := http.post_json('$h.url/api/v1/$prefix', postdata) ?
-		result = response.text
-	}
-	h.cache_set(prefix, postdata, result, cache) ?
-	return result
-}
-
-fn (mut h CoinMarketConnection) get_json(prefix string, data string, cache bool) ?map[string]json2.Any {
+fn (mut h CoinMarketConnection) get_json(prefix string, data string, query string, cache bool) ?map[string]json2.Any {
 	/*
 	Get Request with Json Data
 	Inputs:
@@ -213,7 +149,12 @@ fn (mut h CoinMarketConnection) get_json(prefix string, data string, cache bool)
 	mut result := h.cache_get(prefix, data, cache)
 	if result == '' {
 		// println("MISS1")
-		mut req := http.new_request(http.Method.get, '$h.url/api/v1/$prefix', data) ?
+		mut req := http.Request{}
+		if query != ''{
+			req = http.new_request(http.Method.get, '$h.url/$prefix?$query', data) ?
+		}else{
+			req = http.new_request(http.Method.get, '$h.url/$prefix', data) ?
+		}
 		req.header = h.header() ?
 		res := req.do() ?
 		result = res.text
@@ -244,16 +185,12 @@ fn (mut h CoinMarketConnection) get_json_str(prefix string, data string, query s
 		// println("MISS1")
 		mut req := http.Request{}
 		if query != ''{
-			req = http.new_request(http.Method.get, '$h.url/api/v1/$prefix?$query', data) ?
+			req = http.new_request(http.Method.get, '$h.url/$prefix?$query', data) ?
 		}else{
-			req = http.new_request(http.Method.get, '$h.url/api/v1/$prefix', data) ?
+			req = http.new_request(http.Method.get, '$h.url/$prefix', data) ?
 		}
 		req.header = h.header() ?
-		println('--------------------- Request ----------------------------')
-		println(req)
 		res := req.do() ?
-		println('--------------------- RESPONSE ----------------------------')
-		println(res)
 		result = res.text
 	}
 	// means empty result from cache
@@ -264,45 +201,10 @@ fn (mut h CoinMarketConnection) get_json_str(prefix string, data string, query s
 	return result
 }
 
-fn (mut h CoinMarketConnection) edit_json(prefix string, id int, data string, cache bool) ?map[string]json2.Any {
-	/*
-	Patch Request with Json Data
-	Inputs:
-		prefix: CoinMarket elements types, ex (projects, issues, tasks, ...).
-		id: id of the element.
-		data: Json encoded data.
-		cache: Flag to enable caching.
+pub fn (mut h CoinMarketConnection) token_price_usd () ?f64{
+	prefix := "cryptocurrency/quotes/latest"
+	query := "symbol=TFT"
+	result := h.get_json(prefix, "", query, true) ?
 
-	Output:
-		response: response Json2.Any map.
-	*/
-	mut req := http.new_request(http.Method.patch, '$h.url/api/v1/$prefix/$id', data) ?
-	req.header = h.header() ?
-	res := req.do() ?
-	result := res.text
-	h.cache_set(prefix, data, result, cache) ?
-	data_raw := json2.raw_decode(result) ?
-	data2 := data_raw.as_map()
-	return data2
-}
-
-fn (mut h CoinMarketConnection) delete(prefix string, id int, cache bool) ?bool {
-	/*
-	Delete Request
-	Inputs:
-		prefix: CoinMarket elements types, ex (projects, issues, tasks, ...).
-		id: id of the element.
-		cache: Flag to enable caching.
-
-	Output:
-		bool: True if deleted successfully.
-	*/
-	mut req := http.new_request(http.Method.delete, '$h.url/api/v1/$prefix/$id', '') ?
-	req.header = h.header() ?
-	res := req.do() ?
-	if res.status_code == 204 {
-		return true
-	} else {
-		return false
-	}
+	return result["data"].as_map()["TFT"].as_map()["quote"].as_map()["USD"].as_map()["price"].f64()
 }

--- a/coinmarketcap/coinmarketcap_test.v
+++ b/coinmarketcap/coinmarketcap_test.v
@@ -1,6 +1,6 @@
 module coinmarketcap
 
-fn test_1() {
+fn test_get_tft_price() {
 
 	key := "92be9b29-7f6c-48e4-9ef2-d6aa0550f620"
 	mut args := CMCNewArgs{secret:key}

--- a/coinmarketcap/coinmarketcap_test.v
+++ b/coinmarketcap/coinmarketcap_test.v
@@ -5,18 +5,9 @@ fn test_1() {
 	key := "92be9b29-7f6c-48e4-9ef2-d6aa0550f620"
 	mut args := CMCNewArgs{secret:key}
 	mut c := new(args)
-	prefix := "cryptocurrency/quotes/latest"
-	data := ""
-	query := "symbol=TFT"
-	cache := true
-	result := c.get_json_str(prefix, data, query, cache) or {panic(err)}
-	println(result)
 
-	//need to fetch USD/TFT price
-	//see how we did for taiga how to use the connection
-
-
-
-	panic("sss")
+	//TFT/USD price
+	price := c.token_price_usd() or {panic(err)}
+	println(" 1 TFT = $price USD")
 
 }

--- a/coinmarketcap/coinmarketcap_test.v
+++ b/coinmarketcap/coinmarketcap_test.v
@@ -1,13 +1,16 @@
 module coinmarketcap
-module gittools
-
-import os
 
 fn test_1() {
 
-	key = "92be9b29-7f6c-48e4-9ef2-d6aa0550f620"
-
-	mut c := new({secret:key})
+	key := "92be9b29-7f6c-48e4-9ef2-d6aa0550f620"
+	mut args := CMCNewArgs{secret:key}
+	mut c := new(args)
+	prefix := "cryptocurrency/quotes/latest"
+	data := ""
+	query := "symbol=TFT"
+	cache := true
+	result := c.get_json_str(prefix, data, query, cache) or {panic(err)}
+	println(result)
 
 	//need to fetch USD/TFT price
 	//see how we did for taiga how to use the connection

--- a/liquid/liquid_test.v
+++ b/liquid/liquid_test.v
@@ -1,19 +1,16 @@
 module liquid
-module gittools
-
-import os
 
 fn test_1() {
 
-	// key = "92be9b29-7f6c-48e4-9ef2-d6aa0550f620"
+	key := "92be9b29-7f6c-48e4-9ef2-d6aa0550f620"
+	mut args := LiquidArgs{secret:key}
+	mut l := new(args)
 
-	mut c := new({secret:key})
+	// TFT/USDT price
+	pair_tft_usdt := l.token_price_usdt() or {panic(err)}
+	println("Market Pid for TFT/USDT pair = $pair_tft_usdt")
 
-	//need to fetch USD/TFT price
-	//see how we did for taiga how to use the connection
-
-
-
-	panic("sss")
-
+	// TFT/BTC price
+	pair_tft_btc := l.token_price_btc() or {panic(err)}
+	println("Market Pid for TFT/BTC pair = $pair_tft_btc")
 }

--- a/liquid/liquid_test.v
+++ b/liquid/liquid_test.v
@@ -1,6 +1,6 @@
 module liquid
 
-fn test_1() {
+fn test_get_tft_usdt_price() {
 
 	key := "92be9b29-7f6c-48e4-9ef2-d6aa0550f620"
 	mut args := LiquidArgs{secret:key}
@@ -9,6 +9,14 @@ fn test_1() {
 	// TFT/USDT price
 	pair_tft_usdt := l.token_price_usdt() or {panic(err)}
 	println("Market Pid for TFT/USDT pair = $pair_tft_usdt")
+}
+
+
+fn test_get_tft_btc_price() {
+
+	key := "92be9b29-7f6c-48e4-9ef2-d6aa0550f620"
+	mut args := LiquidArgs{secret:key}
+	mut l := new(args)
 
 	// TFT/BTC price
 	pair_tft_btc := l.token_price_btc() or {panic(err)}


### PR DESCRIPTION
## Description
- Get TFT price from CoinMarketCap
- Get pair TFT/USDT price from liquid
- Get pair TFT/BTC price from liquid

## Output Sample
- CoinMarketCap
```
 1 TFT = 0.07115745727883 USD
```
- Liquid
```
Market Pid for TFT/USDT pair = 0.07045
Market Pid for TFT/BTC pair = 1.41e-06
```

## Related Issues
#35
#36 