### PR TITLE
Publishtools: Implement tracking for unique links

### DIFF
--- a/publisher_config/staticfiles.v
+++ b/publisher_config/staticfiles.v
@@ -64,6 +64,7 @@ fn staticfiles_config(mut c ConfigRoot) {
 		'docsify-charty.min.js':           'https://unpkg.com/@markbattistella/docsify-charty@1.0.5'
 		'docsify-charty.min.css':          'https://unpkg.com/@markbattistella/docsify-charty@1.0.5/dist/docsify-charty.min.css'
 		'charty-custom-style.css':         'https://raw.githubusercontent.com/markbattistella/docsify-charty/fa755c3e058ba1110fc6586a50207626d552b88f/docs/site/style.min.css'
+		'tf-tracker.js':                   'https://cdn.jsdelivr.net/gh/MohamedElmdary/tf-tracker@0.0.2/index.js'
 	}
 }
 

--- a/publisher_core/template_wiki_root.v
+++ b/publisher_core/template_wiki_root.v
@@ -93,6 +93,7 @@ fn template_wiki_root(reponame string, repourl string, trackingid string, opengr
      <script src="d3.min.js"></script>
     <script src="d3-flextree.js"></script>
     <script src="view.mindmap.js"></script>
+    <script src="tf-tracker.js"></script>
 
       <div id="app"></div>
       <script>
@@ -159,6 +160,7 @@ fn template_wiki_root(reponame string, repourl string, trackingid string, opengr
                         new SimpleLightbox(".gallery a");
                     });
                 },
+                tfTracker
             ],
 
             mindmap: {


### PR DESCRIPTION
## In this PR

* Implement tracking endpoint to get requests that used to track activity for unique links

## Related Issue

#60

## Example

1. Open : `<SERVER_ADDR>/info/publishtools?id=<UNIQUE_ID>/#/<PAGE_NAME>`

* This will add a record in redis db with the following info:
  * key: `publish:<UNIQUE_ID>:<USER_IP>:<PAGE_NAME>`
  * value : { "state" : "open", time: *unix_time_now*}

1. Move to another link from the previous page:

* This will add a record in redis db with the following info:
  * key: `publish:<UNIQUE_ID>:<USER_IP>:<PAGE_NAME>`
  * value : { "state" : "move", time: *unix_time_now*}

1. Close page:

* This will add a record in redis db with the following info:
  * key: `publish:<UNIQUE_ID>:<USER_IP>:<PAGE_NAME>`
  * value : { "state" : "close", time: *unix_time_now*}