### PR TITLE
support basic auth in vweb.

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -1,0 +1,30 @@
+## Basic Auth
+
+### Simple and small server with sqlite database has one table `[User]`
+
+### There are just two endpoints
+
+* for `Register` to create a new user with username and password.
+* for `Login`, user will login with his cerdintials.
+
+### There is an example of how to test and use it
+
+<p>
+
+Also, there is `basic_auth` middleware to decode users, you have to send it when you call this method
+
+```v
+    pub fn (mut app App) before_request() {
+        basic_auth(
+            {
+                "<Username1>":"<Password1>",
+                "<Username2>":"<Password2>",
+            } 
+            ,app.Context.req
+        ) or {
+            panic(err)
+        }
+    }
+```
+
+</p>

--- a/auth/basic_auth.v
+++ b/auth/basic_auth.v
@@ -1,0 +1,15 @@
+pub fn basic_auth(users map[string]string, request http.Request)? bool {
+	mut processed_users := map[string]string
+	for u, p in users {
+		encodedauth := base64.encode("$u:$p".bytes())
+		processed_users["Basic $encodedauth"] =  u
+	}
+	headers_keys := request.header.keys()
+	mut value := ""
+	if headers_keys.contains("Authorization"){
+		value = request.header.get_custom(headers_keys[headers_keys.index("Authorization")])?
+	}
+	if processed_users[value] == ''{
+		return false
+	} return true
+}

--- a/auth/examples/client/requests.v
+++ b/auth/examples/client/requests.v
@@ -1,0 +1,51 @@
+module main
+import net.http
+import json
+import encoding.base64
+
+
+pub fn encode(username string, password string) string {
+	return base64.encode("$username:$password".bytes())
+}
+
+pub fn register()?{
+	// Push new user into database if this user not registered yet.
+	// Otherwise, 400 error, but this will pass because login function working based on same cerds.
+	mut header := http.new_header_from_map({
+		http.CommonHeader.content_type: 'application/json',
+	})
+	config := http.FetchConfig{
+		header: header,
+		data: json.encode({"username":"Emad", "password":"0000"}),
+		method: http.Method.post
+	}
+	url := 'http://localhost:8000/users'
+	resp := http.fetch(http.FetchConfig{ ...config, url: url }) or {
+		println('failed to fetch data from the server')
+		return
+	}
+	println(resp)
+}
+
+pub fn login()?{
+	mut header := http.new_header_from_map({
+		http.CommonHeader.content_type: 'application/json'
+	})
+	// header.add_custom_map({"Authorization": "Basic " + encode("Emad", "0000")}) ?
+	config := http.FetchConfig{
+		header: header,
+		method: http.Method.get
+
+	}
+	url := 'http://localhost:8000/users'
+	resp := http.fetch(http.FetchConfig{ ...config, url: url }) or {
+		println('failed to fetch data from the server')
+		return
+	}
+	println(resp)
+}
+
+fn main() {
+	register() or {panic(err)}
+	login() or {panic(err)}	
+}

--- a/auth/examples/server/app.v
+++ b/auth/examples/server/app.v
@@ -1,0 +1,33 @@
+module main
+import sqlite
+import vweb
+import json
+
+struct App {
+	vweb.Context
+	pub mut:
+		db   sqlite.DB
+}
+
+[table: 'User']
+struct User {
+	id      	int    [primary; sql: serial]
+	username 	string [sql: 'username'; unique]
+	password  	string [nonull]
+}
+
+fn (u User) to_json() string {
+    return json.encode(u)
+}
+
+fn main() {
+	db := sqlite.connect('users.db') or { panic(err) }
+	sql db {
+        create table User
+    }
+	http_port := 8000
+    mut app := &App{
+        db: db
+    }
+    vweb.run(app, http_port)
+}

--- a/auth/examples/server/auth.v
+++ b/auth/examples/server/auth.v
@@ -1,0 +1,65 @@
+module main
+import vweb
+import json
+import net.http
+
+
+pub fn (mut app App) before_request() {
+	basic_auth(
+		{
+			"Emad":"0000",
+		} 
+		,mut app
+	) or {
+		panic(err)
+	}
+}
+
+
+['/users'; post]
+fn (mut app App) register() vweb.Result {
+	// Register a new user into database
+	// to make sure that login function working well.
+	user := json.decode(User, app.req.data) or {
+        app.set_status(400, 'Bad Request')
+        er := CustomResponse{400, invalid_json}
+        return app.json(er.to_json())
+    }
+	// To make sure the username is unique.
+	user_found := sql app.db {
+        select from User where username == user.username
+    }
+	if user_found.len > 0 {
+        app.set_status(400, 'Bad Request')
+        er := CustomResponse{400, user_unique}
+        return app.json(er.to_json())
+    }
+	sql app.db {
+        insert user into User
+    }
+	new_id := app.db.last_id() as int
+	created := User{new_id, user.username, user.password}
+	app.set_status(201, 'created')
+	return app.json(created.to_json())
+}
+
+['/users'; get]
+fn (mut app App) login() ?vweb.Result {
+	// To test basic_auth middleware, we need to check if the credentials are valid.
+	// Then we can make a condition on request based on this valid.
+	authorization := app.Context.req.header.get(http.CommonHeader.authorization)?
+	sig := decode(authorization)
+	fileds := sig.split(":")
+	username, password := fileds[0], fileds[1]
+	user_found := sql app.db {
+        select from User where username == username && password == password
+    }
+	if user_found == []{
+        app.set_status(404, 'Not Found')
+        er := CustomResponse{404, user_not_found}
+        return app.json(er.to_json())
+    }
+	ret := json.encode(user_found)
+	app.set_status(200, 'Successfully Logged in')
+	return app.json(ret)
+}

--- a/auth/examples/server/util.v
+++ b/auth/examples/server/util.v
@@ -1,0 +1,55 @@
+module main
+import json
+import encoding.base64
+import net.http
+
+
+struct CustomResponse {
+	status  int
+	message string
+}
+
+fn (c CustomResponse) to_json() string {
+    return json.encode(c)
+}
+
+const (
+    invalid_json   = 'Invalid JSON Payload.'
+    user_not_found = 'User not found.'
+	user_unique = 'User with this username already exists.'
+    invalid_user = 'Please make sure that you entered a valid username and password.'
+	wrong_credential = 'Invalid credentials'
+	no_signature = 'Make sure that you have an "Authorization" in your header.'
+)
+
+pub fn encode(username string, password string) string {
+	return base64.encode("$username:$password".bytes())
+}
+
+pub fn decode(signature string) string{
+	mut sig := signature
+	if signature.contains("Basic "){
+		sig = signature.split(" ")[1]
+	}
+	sig = base64.decode(sig).bytestr()
+	return sig
+}
+
+pub fn basic_auth(users map[string]string, mut app App)?{
+	mut processed_users := map[string]string
+	for u, p in users {
+		encodedauth := base64.encode("$u:$p".bytes())
+		processed_users["Basic $encodedauth"] =  u
+	}
+	headers_keys := app.Context.req.header.keys()
+	mut value := ""
+	if headers_keys.contains("Authorization"){
+		value = app.Context.req.header.get_custom(headers_keys[headers_keys.index("Authorization")])?
+	}
+	if processed_users[value] == ''{
+		app.set_status(403, 'ForbiddenXYZ')
+		app.add_header("WWW-Authenticate", 'Basic realm="private"')
+        er := CustomResponse{403, 'ForbiddenXYZ'}
+        app.json(er.to_json())
+	}
+}


### PR DESCRIPTION
## Related Issues
[#77 - support basic auth in vweb](https://github.com/freeflowuniverse/crystallib/issues/77)

## Description
### Simple and small server with SQLite database has one table `[User]`

### There are just two endpoints

* for `Register` to create a new user with a username and password.
* for `Log in`, the user will log in with his credentials.

### There is an example of how to test and use it

<p>

Also, there is `basic_auth` middleware to decode users, you have to send it when you call this method

```v
    pub fn (mut app App) before_request() {
        basic_auth(
            {
                "<Username1>":"<Password1>",
                "<Username2>":"<Password2>",
            } 
            ,app.Context.req
        ) or {
            panic(err)
        }
    }
```

</p>
