### PR TITLE
Server class in net.websocket has been modified resulting in failing test

### DIFF
--- a/rpcwebsocket/rpcw_test.v
+++ b/rpcwebsocket/rpcw_test.v
@@ -31,7 +31,7 @@ fn test_client_server() {
 	mut myserver := new_rpcwsserver(port, handler, &logger)!
 	t_server := spawn myserver.run()
 	// wait till server ready
-	for myserver.server.state != .open {
+	for myserver.server.get_state() != .open {
 		time.sleep(100 * time.millisecond)
 	}
 


### PR DESCRIPTION
The attribute state has been removed and replaced by a struct. A new function state was also introduced which we should start using instead. 

The failing test was fixed. 