### PR TITLE
146 openrpc document is not correct 1

### DIFF
--- a/jsonschema/generate.v
+++ b/jsonschema/generate.v
@@ -74,6 +74,15 @@ pub fn typesymbol_to_schema(symbol_ string) SchemaRef {
 			additional_properties: typesymbol_to_schema(map_type)
 		})
 	} else if symbol[0].is_capital() {
+		// todo: better imported type handling
+		if symbol == 'Uint128' {
+			return SchemaRef(Schema{
+				typ: 'integer'
+				minimum: Number(0)
+				// todo: implement uint128 number
+				// maximum: Number('340282366920938463463374607431768211455')
+			})
+		}
 		return SchemaRef(Reference{
 			ref: '#/components/schemas/${symbol}'
 		})

--- a/jsonschema/schema.v
+++ b/jsonschema/schema.v
@@ -27,11 +27,12 @@ pub mut:
 	defs                  map[string]Schema
 	one_of	?[]SchemaRef [json: 'oneOf']
 
+	// todo: make fields optional upon the fixing of https://github.com/vlang/v/issues/18775
 	// from https://git.sr.ht/~emersion/go-jsonschema/tree/master/item/schema.go
 	// Validation for numbers
-	multiple_of      Number [json: "multipleOf"]
-	maximum          Number [json_as_number]
-	exclusive_maximum Number [json: "exclusiveMaximum"]
-	minimum          Number
-	exclusive_minimum Number [json: "exclusiveMinimum"]
+	multiple_of      Number [json: "multipleOf"; omitempty]
+	maximum          Number [omitempty]
+	exclusive_maximum Number [json: "exclusiveMaximum"; omitempty]
+	minimum          Number [omitempty]
+	exclusive_minimum Number [json: "exclusiveMinimum"; omitempty]
 }

--- a/jsonschema/schema.v
+++ b/jsonschema/schema.v
@@ -9,6 +9,8 @@ pub:
 	ref string [json: '\$ref'; required]
 }
 
+type Number = int
+
 // https://json-schema.org/draft-07/json-schema-release-notes.html
 pub struct Schema {
 pub mut:
@@ -24,4 +26,12 @@ pub mut:
 	items                 Items
 	defs                  map[string]Schema
 	one_of	?[]SchemaRef [json: 'oneOf']
+
+	// from https://git.sr.ht/~emersion/go-jsonschema/tree/master/item/schema.go
+	// Validation for numbers
+	multiple_of      Number [json: "multipleOf"]
+	maximum          Number [json_as_number]
+	exclusive_maximum Number [json: "exclusiveMaximum"]
+	minimum          Number
+	exclusive_minimum Number [json: "exclusiveMinimum"]
 }

--- a/openrpc/cli/cli.v
+++ b/openrpc/cli/cli.v
@@ -49,7 +49,7 @@ fn main() {
 	docgen_cmd.add_flag(Flag{
 		flag: .string_array
 		name: 'exclude_dirs'
-		abbrev: 'd'
+		abbrev: 'ed'
 		description: 'Directories to be excluded from source code to generate document from.'
 	})
 	docgen_cmd.add_flag(Flag{


### PR DESCRIPTION
This pr fixes the problem ["The Uint128 type imported from vlib's math.unsigned lacks a schema definition as the type isn't defined within the library."](https://github.com/threefoldtech/web3_proxy/issues/146#issuecomment-1618219397_)

This is a temporary fix, as the underlying issue has not been solved. Ideally the codeparser module should optionally parse code on imported and used structs, which the OpenRPC document generator can use to create JSON Schema's for imported structs.