### PR TITLE
Add docker examples

### DIFF
--- a/crystallib/osal/docker/examples/compose.v
+++ b/crystallib/osal/docker/examples/compose.v
@@ -1,0 +1,25 @@
+import freeflowuniverse.crystallib.osal.docker
+import os
+pub fn main() {
+	
+	registration_code := os.getenv("PRESEARCH_CODE") 
+	if registration_code == '' {
+		println("Can't find presearch registration code please run 'export PRESEARCH_CODE=...'")
+		exit(1)
+	}
+
+	mut engine := docker.new(prefix:"", localonly: true)!
+	mut recipe := engine.compose_new(name: "presearch")
+	mut presearch_node := recipe.service_new(name:"presearch_node", image:"presearch/node")!
+	
+	
+	presearch_node.volume_add("/presearch-node-storage", "/app/node")!
+	presearch_node.env_add( "REGISTRATION_CODE","${registration_code}")
+
+	
+	mut presearch_updater := 	recipe.service_new(name:"presearch_updater", image:"presearch/auto-updater")!
+	presearch_updater.volume_add("/var/run/docker.sock", "/var/run/docker.sock")!
+
+	recipe.start()!
+
+}

--- a/crystallib/osal/docker/examples/dev_tools.v
+++ b/crystallib/osal/docker/examples/dev_tools.v
@@ -1,0 +1,30 @@
+import freeflowuniverse.crystallib.osal.docker
+
+fn main() {
+
+  mut engine := docker.new(prefix: "", localonly: true)!
+
+  mut r := engine.recipe_new(name: 'dev_tools', platform: .ubuntu)
+
+  r.add_from(image: 'ubuntu', tag: 'latest')!
+
+  r.add_run(cmd: 'apt update -y 
+  apt install -y git vim wget openssh-server')!
+
+  r.add_run(cmd: 'wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.5/zinit 
+  chmod +x /sbin/zinit')!
+
+  r.add_zinit_cmd(name: "sshd", exec: "/usr/bin/sshd -D")!
+
+	r.add_zinit_cmd(name: "sshkey", exec:'if [ ! -z "\$SSH_KEY" ]; then
+		mkdir -p /var/run/sshd
+		mkdir -p /root/.ssh
+		touch /root/.ssh/authorized_keys
+		
+		chmod 700 /root/.ssh
+		chmod 600 /root/.ssh/authorized_keys
+
+		echo "\$SSH_KEY" >> /root/.ssh/authorized_keys
+fi')!
+  r.build(true)!
+}

--- a/crystallib/osal/docker/examples/dev_tools.v
+++ b/crystallib/osal/docker/examples/dev_tools.v
@@ -4,26 +4,15 @@ fn main() {
 
   mut engine := docker.new(prefix: "", localonly: true)!
 
-  mut r := engine.recipe_new(name: 'dev_tools', platform: .ubuntu)
+  mut r := engine.recipe_new(name: 'dev_tools', platform: .alpine)
 
-  r.add_from(image: 'ubuntu', tag: 'latest')!
+  r.add_from(image: 'alpine', tag: 'latest')!
 
-  r.add_run(cmd: 'apt update -y 
-  apt install -y git vim wget openssh-server')!
+  r.add_package(name:"git,vim")!
 
   r.add_zinit()!
 
-  r.add_zinit_cmd(name: "sshd", exec: "/usr/bin/sshd -D")!
+  r.add_sshserver()!
 
-	r.add_zinit_cmd(name: "sshkey", exec:'if [ ! -z "\$SSH_KEY" ]; then
-		mkdir -p /var/run/sshd
-		mkdir -p /root/.ssh
-		touch /root/.ssh/authorized_keys
-		
-		chmod 700 /root/.ssh
-		chmod 600 /root/.ssh/authorized_keys
-
-		echo "\$SSH_KEY" >> /root/.ssh/authorized_keys
-fi')!
   r.build(true)!
 }

--- a/crystallib/osal/docker/examples/dev_tools.v
+++ b/crystallib/osal/docker/examples/dev_tools.v
@@ -11,8 +11,7 @@ fn main() {
   r.add_run(cmd: 'apt update -y 
   apt install -y git vim wget openssh-server')!
 
-  r.add_run(cmd: 'wget -O /sbin/zinit https://github.com/threefoldtech/zinit/releases/download/v0.2.5/zinit 
-  chmod +x /sbin/zinit')!
+  r.add_zinit()!
 
   r.add_zinit_cmd(name: "sshd", exec: "/usr/bin/sshd -D")!
 

--- a/crystallib/osal/docker/examples/tf_dashboard.v
+++ b/crystallib/osal/docker/examples/tf_dashboard.v
@@ -1,0 +1,40 @@
+import freeflowuniverse.crystallib.osal.docker
+
+pub fn main()  {
+	mut engine := docker.new(prefix: "", localonly: true)!
+  
+  mut recipe := engine.recipe_new(name: "tf_dashboard", platform: .alpine)
+	
+  println(' - build dashboard')
+
+
+  recipe.add_from(image: 'nginx', tag: 'alpine')!
+
+	recipe.add_nodejsbuilder()!
+
+	recipe.add_run(cmd: 'apk add git')!
+	recipe.add_run(cmd: 'npm i -g yarn')!
+	recipe.add_run(
+		cmd: '
+		git clone https://github.com/threefoldtech/tfgrid-sdk-ts.git /app 
+		cd /app/packages/dashboard
+		yarn install
+		yarn lerna run build --no-private 
+    yarn workspace @threefold/dashboard build
+	'
+	)!
+	recipe.add_run(
+		cmd: '
+		rm /etc/nginx/conf.d/default.conf
+		cp /app/packages/dashboard/nginx.conf /etc/nginx/conf.d
+		apk add --no-cache bash
+		chmod +x /app/packages/dashboard/scripts/build-env.sh
+		cp -r /app/packages/dashboard/dist /usr/share/nginx/html
+	'
+	)!
+	recipe.add_run(cmd: 'echo "daemon off;" >> /etc/nginx/nginx.conf')!
+	recipe.add_cmd(cmd: '/bin/bash -c /app/packages/dashboard/scripts/build-env.sh')!
+	recipe.add_entrypoint(cmd: 'nginx')!
+
+	recipe.build(false)!
+}


### PR DESCRIPTION
We tried to use as many recipes by adding three examples :

- TF Dashboard
- Development environment that contains [ zinit, ssh, vim ]
- Presearch Compose

related issue: #241 
Co-authored-by: @Omarabdul3ziz 