### PR TITLE
changes in book.toml values for mdbooks

### DIFF
--- a/crystallib/webtools/mdbook/template/book.toml
+++ b/crystallib/webtools/mdbook/template/book.toml
@@ -7,7 +7,7 @@ title = "@book.args.title"
 
 [output.html.fold]
 enable = true
-level = 0
+level = 1
 
 
 [output]
@@ -21,7 +21,7 @@ additional-js = ["mermaid.min.js", "mermaid-init.js", "echarts.min.js"]
 create-missing = false
 
 [output.html.print]
-enable = true
+enable = false
 
 [preprocessor]
 


### PR DESCRIPTION
as @Mik-TF requested, i changed two values in the book.toml file

- output.html.fold level = 1
  - ![level1](https://github.com/freeflowuniverse/crystallib/assets/26723944/c387df2f-b10f-4c44-af3f-ab6f9825736b)
- output.html.print enable = false
  - ensures that the print button on the top right is not displayed as the manual is so big it's impossible to print the book, so it just bugs when the user tries to print with this button

