### PR TITLE
added print and fold level as args in book toml

### DIFF
--- a/crystallib/webtools/mdbook/mdbook.v
+++ b/crystallib/webtools/mdbook/mdbook.v
@@ -24,7 +24,7 @@ pub mut:
 	name         string @[required]
 	title        string
 	foldlevel	 int = 0
-	printbook    string = "true"
+	printbook    string = 'true'
 	summary_url  string // url of the summary.md file
 	summary_path string // can also give the path to the summary file (can be the dir or the summary itself)
 	doctree_url  string

--- a/crystallib/webtools/mdbook/mdbook.v
+++ b/crystallib/webtools/mdbook/mdbook.v
@@ -23,6 +23,8 @@ pub struct MDBookArgs {
 pub mut:
 	name         string @[required]
 	title        string
+	foldlevel	 int = 0
+	printbook    string = "true"
 	summary_url  string // url of the summary.md file
 	summary_path string // can also give the path to the summary file (can be the dir or the summary itself)
 	doctree_url  string

--- a/crystallib/webtools/mdbook/template/book.toml
+++ b/crystallib/webtools/mdbook/template/book.toml
@@ -7,7 +7,7 @@ title = "@book.args.title"
 
 [output.html.fold]
 enable = true
-level = 0
+level = "@book.args.foldlevel"
 
 
 [output]
@@ -21,7 +21,7 @@ additional-js = ["mermaid.min.js", "mermaid-init.js", "echarts.min.js"]
 create-missing = false
 
 [output.html.print]
-enable = true
+enable = "@book.args.printbook"
 
 [preprocessor]
 


### PR DESCRIPTION
# Situation

hero mdbook currently uses a book.toml template. 

To set the title in book.toml, we need to set the book_collection as follow (e.g. [here](https://git.ourworld.tf/tfgrid/info_tfgrid/src/branch/main/heroscript/manual/book_collections.md)):

```
!!book.generate name:'manual' title:'ThreeFold Manual Version'
```

# Proposition

In this PR, I propose to add two parameters to be set with book_collection:

- fold level, so we can have 0, 1, etc.
- print true or false

For print, this is useful since some books are too big to be printed on the webpage, so we need to be able to set it to false

For fold level, we want to be able to see some levels of the TOC for big books.

E.g. when a user opens a new URL leading to an mdbook

level = 0 will give this for the manual:

![image](https://github.com/freeflowuniverse/crystallib/assets/77026219/6a444e94-89ee-4e3d-8eb3-ec9df973d7ad)


level = 1 will give this:

![image](https://github.com/freeflowuniverse/crystallib/assets/77026219/2b0820e7-6881-455c-9bcb-ce08447874a6)

# Mdbook creator POV

As we want the simplest UX for the mdbook creator, we set default values for those parameters: print is set to true, and fold level to 0. In short, this doesn't change anything for current mdbooks. It only adds more possibilities.

# How to use it

When creating a book, we can set the print and fold level like this:

```
!!book.generate name:'manual' title:'ThreeFold Manual Version' printbook:'false' foldlevel:'1'
```

But we can still use the current method and it will set print to true and fold level to 0:

```
!!book.generate name:'manual' title:'ThreeFold Manual Version'
```
