### PR TITLE
updated hero installer url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ curl https://raw.githubusercontent.com/freeflowuniverse/crystallib/development/s
 bash /tmp/install.sh
 
 #with hero (will compile hero as well)
-curl https://raw.githubusercontent.com/freeflowuniverse/crystallib/development/scripts/build_hero.sh > /tmp/build_hero.sh
+curl https://raw.githubusercontent.com/freeflowuniverse/crystallib/development/scripts/installer_hero.sh > /tmp/build_hero.sh
 bash /tmp/build_hero.sh
 ```
 


### PR DESCRIPTION
# Related Issue

#417 

# Work Done

- updated url with @scottyeager's suggestion to properly install hero

# Notes

Might not be the best fix for the situation, maybe the script build_hero.sh should simply be updated.