### PR TITLE
fixed summary and urls can't take parentheses in description

### DIFF
--- a/crystallib/data/markdownparser/elements/element_link.v
+++ b/crystallib/data/markdownparser/elements/element_link.v
@@ -190,7 +190,7 @@ fn (mut link Link) parse() {
 		link.cat = .image
 	}
 	link.description = link.content.all_after('[').all_before_last(']').trim_space()
-	link.url = link.content.all_after('(').all_before(')').trim_space()
+	link.url = link.content.all_after('](').all_before(')').trim_space()
 	if link.url.contains('#') {
 		link.anchor = link.url.all_after('#')
 		// link.url = link.url.all_before('#')

--- a/crystallib/webtools/mdbook/summary.v
+++ b/crystallib/webtools/mdbook/summary.v
@@ -58,7 +58,7 @@ pub fn (mut book MDBook) summary() !Summary {
 		}
 
 		description := line.all_after_first('[').all_before(']').trim_space()
-		path := line.all_after_first('(').all_before_last(')').trim_space()
+		path := line.all_after_last('(').all_before_last(')').trim_space()
 
 		if !path.contains('/') {
 			book.error(


### PR DESCRIPTION
# Related Issue

- To fix the fact that summary.md and URLs can't take parentheses in description of a line

# Work Done

- made sure it checks for the last iteration of (

# Notes

The workflow is not successful for something else than this change. Hero works, as stated in another PR.