### PR TITLE
added if statement for url collection and filename

### DIFF
--- a/crystallib/data/markdownparser/elements/element_link.v
+++ b/crystallib/data/markdownparser/elements/element_link.v
@@ -325,6 +325,10 @@ fn (mut link Link) parse() {
 				return
 			}
 			link.cat = LinkType.page
+			if link.filename.contains('@@') {
+				link.filename = '../' + link.filename.all_before('@@') + '/' + link.filename.all_after('@@')
+				link.site = ''
+			}
 		} else if ext in ['html', 'htm'] {
 			if link.cat == .image {
 				link.error('any link starting with ! needs to be image now html, content is ${link.content}')


### PR DESCRIPTION
# Related Issue

- Fix #422 #421 

# Work Done

- added an if in the element_link to make sure we can use collection and filename from other collections
- this also fixes the fact that the first page of an mdbook can be example.com, but when you click on the first page from within the book (say on the left-side menu) it will be example.com/intro. This leads to issue with URLs on the first page. It's fixed with this @@ trick (see commit)

# How to Use

- make a URL for a file within the current collection: \[description\](filename)
- make a URL for a file from a different collection: \[description\](collection@@filename)
- note: don't need to add .md

# Notes

collection:filename should work but it doesn't on my end. This code shouldn't interfere with any hero features so I think we can go forward. Note that hero doesn't compile from the installer and I am using the branch development_urlwork to compile the hero binary